### PR TITLE
Pull request to add configuration files as examples

### DIFF
--- a/conf/architecture.conf
+++ b/conf/architecture.conf
@@ -1,0 +1,40 @@
+# Example for architecture.conf
+# All the default values have to be adpated
+# This file is not meant to be a ready to work one you will have to tune it
+###############################################################################
+
+[cluster2]
+nodes=nodes1,nodes2
+
+[cluster2/nodes1]
+names= cn[0001-0100]
+cpu=12
+machine=Vendor2
+flops=3000000000000
+
+[cluster2/nodes2]
+names= bigmem[01-10]
+cpu=12
+machine=Vendor2
+flops=3000000000000
+
+[cluster1]
+nodes=frontal,nodes1/nodes2
+
+[cluster1/frontal]
+names= frontal1,frontal2
+cpu=8
+machine=Vendor1
+flops=2500000000000
+
+[cluster1/nodes1]
+names= compute[001-100]
+cpu=8
+machine=Vendor1
+flops=2500000000000
+
+[cluster1/nodes2]
+names= bigmem[001-010]
+cpu=8
+machine=Vendor1
+flops=2500000000000

--- a/conf/hpcstats.conf
+++ b/conf/hpcstats.conf
@@ -1,0 +1,76 @@
+# Example of hpcstats.conf
+# Most of the default values can be change and have to be adpated
+# This file is not meant to be a ready to work one you might have to tune it
+###############################################################################
+
+[clusters]
+clusters = cluster2,cluster1
+
+[hpcstatsdb]
+hostname = localhost
+dbname = supervisiondb
+port = 5432
+user = <myuser>
+password = <password>
+
+# Plugins activated
+###############################################################################
+[jobs]
+slurm = True
+torque = True
+loadleveler = False
+
+[users]
+ldap = True
+xls+ldap = True
+
+[architecture]
+conffile = False
+
+# Cluster2
+###############################################################################
+[cluster2]
+jobs = slurm
+users = xls+ldap
+
+[cluster2/ldap]
+url = ldaps://<ldapuri>/
+port = 636 
+dn = <dn>
+basedn = <basedn>
+password = <password>
+attributes = uidNumber
+filter = (objectClass=*)
+anonymous_connection = False
+safe_mode = True
+
+[cluster2/xls]
+file = <pathtofile>
+sheet = <sheetname>
+
+[cluster2/slurm]
+host = <slurm_mysql_db_ip>
+name = slurm_acct_db
+user = slurm
+password = <slurmpasswd>
+
+# Cluster 1
+###############################################################################
+[cluster1]
+jobs = torque
+users = ldap
+
+[cluster1/ldap]
+server = <ldap IP>
+port = 389
+dn = <dn>
+basedn = <basedn>
+password = <password>
+attributes = uid,uidNumber,createTimestamp
+filter = (objectClass=*) 
+anonymous_connection = True
+safe_mode = False
+
+[cluster1/torque]
+logdir = <folder for torque log files>
+


### PR DESCRIPTION
Added : 
- confs/architecture.conf
- confs/hpcstats.conf

Without them it is very difficult to get started as error handling is pretty poor it might be difficult to find what is actually missing in configuration without a concrete example.

Those are not ready to work ones they have to be heavily tuned.
